### PR TITLE
Bump Release - 0.1.4

### DIFF
--- a/netapp_ocum/__init__.py
+++ b/netapp_ocum/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 name = 'netapp_ocum'


### PR DESCRIPTION
This bumps the release to 0.1.4 for publishing on PyPi.